### PR TITLE
PassThroughEnv: Pass the full env through in TRACKING mode

### DIFF
--- a/import_tracker/import_tracker.py
+++ b/import_tracker/import_tracker.py
@@ -7,6 +7,7 @@ through import statements
 from contextlib import contextmanager
 from types import ModuleType
 from typing import Dict, List, Optional
+import copy
 import importlib
 import inspect
 import json
@@ -210,14 +211,10 @@ def _track_deps(name: str, package: Optional[str] = None):
     )
     if package is not None:
         cmd += f" --package {package}"
-    res = subprocess.run(
-        shlex.split(cmd),
-        stdout=subprocess.PIPE,
-        env={
-            MODE_ENV_VAR: LAZY,
-            "PYTHONPATH": ":".join(sys.path),
-        },
-    )
+    env = dict(copy.deepcopy(os.environ))
+    env[MODE_ENV_VAR] = LAZY
+    env["PYTHONPATH"] = ":".join(sys.path)
+    res = subprocess.run(shlex.split(cmd), stdout=subprocess.PIPE, env=env)
     assert res.returncode == 0, f"Failed to track {name}"
     deps = json.loads(res.stdout)
 

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -88,6 +88,7 @@ def remove_test_deps(deps):
             continue
     return deps
 
+
 ## Implementations #############################################################
 
 

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -77,6 +77,17 @@ def TRACKING_MODE():
         yield
 
 
+def remove_test_deps(deps):
+    """If running with pytest coverage enabled, these deps will show up. We
+    don't want run-env-dependent tests, so we just pop them out.
+    """
+    for test_dep in ["pytest_cov", "coverage"]:
+        try:
+            deps.remove(test_dep)
+        except ValueError:
+            continue
+    return deps
+
 ## Implementations #############################################################
 
 

--- a/test/sample_libs/env_import/__init__.py
+++ b/test/sample_libs/env_import/__init__.py
@@ -2,6 +2,7 @@
 This is a sample library that requires an env var at import time
 """
 
+# Standard
 import os
 
 assert "SAMPLE_ENV_VAR" in os.environ

--- a/test/sample_libs/env_import/__init__.py
+++ b/test/sample_libs/env_import/__init__.py
@@ -1,0 +1,7 @@
+"""
+This is a sample library that requires an env var at import time
+"""
+
+import os
+
+assert "SAMPLE_ENV_VAR" in os.environ

--- a/test/test_import_tracker.py
+++ b/test/test_import_tracker.py
@@ -19,6 +19,7 @@ from test.helpers import (
     LAZY_MODE,
     PROACTIVE_MODE,
     TRACKING_MODE,
+    remove_test_deps,
     reset_static_trackers,
     reset_sys_modules,
 )
@@ -300,10 +301,12 @@ def test_import_module_tracking_direct(TRACKING_MODE):
     """
     submod1 = import_tracker.import_module("sample_lib.submod1")
     submod2 = import_tracker.import_module("sample_lib.submod2")
-    assert import_tracker.get_required_imports("sample_lib.submod1") == [
+    assert remove_test_deps(import_tracker.get_required_imports("sample_lib.submod1")) == [
         "conditional_deps"
     ]
-    assert import_tracker.get_required_imports("sample_lib.submod2") == ["alog"]
+    assert remove_test_deps(import_tracker.get_required_imports("sample_lib.submod2")) == [
+        "alog"
+    ]
 
 
 def test_import_module_tracking_update_static(TRACKING_MODE):

--- a/test/test_import_tracker.py
+++ b/test/test_import_tracker.py
@@ -301,12 +301,12 @@ def test_import_module_tracking_direct(TRACKING_MODE):
     """
     submod1 = import_tracker.import_module("sample_lib.submod1")
     submod2 = import_tracker.import_module("sample_lib.submod2")
-    assert remove_test_deps(import_tracker.get_required_imports("sample_lib.submod1")) == [
-        "conditional_deps"
-    ]
-    assert remove_test_deps(import_tracker.get_required_imports("sample_lib.submod2")) == [
-        "alog"
-    ]
+    assert remove_test_deps(
+        import_tracker.get_required_imports("sample_lib.submod1")
+    ) == ["conditional_deps"]
+    assert remove_test_deps(
+        import_tracker.get_required_imports("sample_lib.submod2")
+    ) == ["alog"]
 
 
 def test_import_module_tracking_update_static(TRACKING_MODE):

--- a/test/test_import_tracker.py
+++ b/test/test_import_tracker.py
@@ -331,3 +331,11 @@ def test_import_module_tracking_with_package(TRACKING_MODE):
     expected (this is mostly for coverage)
     """
     import_tracker.import_module(".submod1", "sample_lib")
+
+
+def test_import_module_tracking_env_passthrough(TRACKING_MODE):
+    """Test that performing tracking when the submodule has a package works as
+    expected (this is mostly for coverage)
+    """
+    os.environ["SAMPLE_ENV_VAR"] = "something"
+    import_tracker.import_module("env_import")


### PR DESCRIPTION
## Description

This PR passes all `os.environ` variables through to the `subprocess` in `TRACKING` mode. Some libraries require certain env-based config at import time, so without this those libraries may break or follow different paths when imported in the `subprocess`.