### PR TITLE
GetTrackedImports: Add get_tracked_modules with tests

### DIFF
--- a/import_tracker/__init__.py
+++ b/import_tracker/__init__.py
@@ -13,6 +13,7 @@ from .import_tracker import (
     default_import_mode,
     get_required_imports,
     get_required_packages,
+    get_tracked_modules,
     import_module,
     set_static_tracker,
 )

--- a/import_tracker/import_tracker.py
+++ b/import_tracker/import_tracker.py
@@ -146,6 +146,14 @@ def get_required_packages(name: str) -> List[str]:
     return sorted(list(required_pkgs))
 
 
+def get_tracked_modules(prefix: str = "") -> List[str]:
+    """Get all tracked modules whose name starts with the given prefix.
+    Libraries which implement static tracking can use this to determine the full
+    set of tracked modules in a central location.
+    """
+    return [name for name in _module_dep_mapping if name.startswith(prefix)]
+
+
 @contextmanager
 def default_import_mode(import_mode: str):
     """This contextmanager will set the default import mode and then reset it on

--- a/test/test_import_tracker.py
+++ b/test/test_import_tracker.py
@@ -167,6 +167,35 @@ def test_get_required_packages_no_package_lookup():
     assert len(warns) == 1
 
 
+## get_tracked_modules #########################################################
+
+
+def test_get_tracked_modules_prefix(BEST_EFFORT_MODE):
+    """Test that get_tracked_modules returns all tracked modules for the given
+    prefix
+    """
+    # Local
+    import sample_lib
+
+    assert import_tracker.get_tracked_modules("sample_lib.nested") == [
+        "sample_lib.nested.submod3"
+    ]
+
+
+def test_get_tracked_modules_no_prefix(BEST_EFFORT_MODE):
+    """Test that get_tracked_modules returns all tracked modules when no prefix
+    is given
+    """
+    # Local
+    import sample_lib
+
+    assert import_tracker.get_tracked_modules() == [
+        "sample_lib.nested.submod3",
+        "sample_lib.submod1",
+        "sample_lib.submod2",
+    ]
+
+
 ## import_module ###############################################################
 
 #################


### PR DESCRIPTION
## Description

Add `get_tracked_imports` to return the set of tracked imports for a given library