### PR TITLE
EvenLazierErrors: Expose LazyModule in the public API

### DIFF
--- a/import_tracker/__init__.py
+++ b/import_tracker/__init__.py
@@ -10,6 +10,7 @@ from .import_tracker import (
     MODE_ENV_VAR,
     PROACTIVE,
     TRACKING,
+    LazyModule,
     default_import_mode,
     get_required_imports,
     get_required_packages,


### PR DESCRIPTION
## Description

Include `LazyModule` in the set of attributes exposed at the top level. It is useful as a standalone construct should be public.