### PR TITLE
Pass through unknown imports as packages

### DIFF
--- a/import_tracker/import_tracker.py
+++ b/import_tracker/import_tracker.py
@@ -139,10 +139,14 @@ def get_required_packages(name: str) -> List[str]:
     # Merge the required packages for each
     required_pkgs = set()
     for mod in required_modules:
+        # If there is a known mapping, use it
         if mod in _module_to_pkg:
             required_pkgs.update(_module_to_pkg[mod])
+
+        # Otherwise, assume that the name of the module is itself the name of
+        # the package
         else:
-            warnings.warn(f"Could not find any required packages for {mod}")
+            required_pkgs.add(mod)
     return sorted(list(required_pkgs))
 
 

--- a/test/test_import_tracker.py
+++ b/test/test_import_tracker.py
@@ -157,14 +157,11 @@ def test_get_required_packages_untracked():
 
 
 def test_get_required_packages_no_package_lookup():
-    """Test that an appropriate warning is issued if one of the imports does not
-    have a known package name
-    """
-    with warnings.catch_warnings(record=True) as warns:
-        warnings.simplefilter("always")
-        submod1 = import_tracker.import_module("sample_lib.submod1")
-        import_tracker.get_required_packages("sample_lib.submod1")
-    assert len(warns) == 1
+    """Test that an import without a known package is passed through"""
+    submod1 = import_tracker.import_module("sample_lib.submod1")
+    assert "conditional_deps" in import_tracker.get_required_packages(
+        "sample_lib.submod1"
+    )
 
 
 ## get_tracked_modules #########################################################


### PR DESCRIPTION
## Description

In `get_required_packages` we want all imports represented, so we assume that if a package name can't be found, the import name itself is the package.