### PR TITLE
Even lazier errors

### DIFF
--- a/import_tracker/lazy_import_errors.py
+++ b/import_tracker/lazy_import_errors.py
@@ -31,6 +31,257 @@ def lazy_import_errors():
 ## Implementation Details ######################################################
 
 
+class _LazyErrorAttr(type):
+    """This object is used to recursively allow attribute access from a
+    _LazyErrorModule and only trigger an error when an attribute is used
+
+    NOTE: This object _is_ itself a type. This is done to ensure that attributes
+        on a missing module which are types in the module itself can still be
+        treated as types. This is particularly important when deserializing a
+        pickled object whose type is not available at unpickling time. By acting
+        as a type, this object ensures that the appropriate ModuleNotFoundError
+        is raised rather than an opaque error about NEWOBJ not being a type.
+    """
+
+    def __new__(cls, missing_module_name: str):
+        return super().__new__(cls, f"_LazyErrorAttr[{missing_module_name}]", (), {})
+
+    def __init__(self, missing_module_name: str):
+        """Store the name of the attribute being accessed and the missing module"""
+
+        def _raise(*_, **__):
+            raise ModuleNotFoundError(f"No module named '{missing_module_name}'")
+
+        self._raise = _raise
+
+    def __getattr__(self, name: str) -> "_LazyErrorAttr":
+        """Return self so that attributes can be extracted recursively"""
+        return self
+
+    ##
+    # Override _everything_ to raise! This list is taken directly from the
+    # CPython source code:
+    # https://github.com/python/cpython/blob/main/Objects/typeobject.c#L7986
+    #
+    # The only exclusions from the set defined above are those which are used as
+    # part of the actual import mechanism:
+    #   __bool__
+    #   __del__
+    #   __getattr__
+    #   __getattribute__
+    #   __init__
+    #   __len__
+    #   __new__
+    #   __setattr__
+    ##
+    def __abs__(self, *_, **__):
+        self._raise()
+
+    def __add__(self, *_, **__):
+        self._raise()
+
+    async def __aiter__(self, *_, **__):
+        self._raise()
+
+    def __and__(self, *_, **__):
+        self._raise()
+
+    async def __anext__(self, *_, **__):
+        self._raise()
+
+    def __await__(self, *_, **__):
+        self._raise()
+
+    def __call__(self, *_, **__):
+        self._raise()
+
+    def __contains__(self, *_, **__):
+        self._raise()
+
+    def __delattr__(self, *_, **__):
+        self._raise()
+
+    def __delete__(self, *_, **__):
+        self._raise()
+
+    def __delitem__(self, *_, **__):
+        self._raise()
+
+    def __eq__(self, *_, **__):
+        self._raise()
+
+    def __float__(self, *_, **__):
+        self._raise()
+
+    def __floordiv__(self, *_, **__):
+        self._raise()
+
+    def __ge__(self, *_, **__):
+        self._raise()
+
+    def __get__(self, *_, **__):
+        self._raise()
+
+    def __getitem__(self, *_, **__):
+        self._raise()
+
+    def __gt__(self, *_, **__):
+        self._raise()
+
+    def __hash__(self, *_, **__):
+        self._raise()
+
+    def __iadd__(self, *_, **__):
+        self._raise()
+
+    def __iand__(self, *_, **__):
+        self._raise()
+
+    def __ifloordiv__(self, *_, **__):
+        self._raise()
+
+    def __ilshift__(self, *_, **__):
+        self._raise()
+
+    def __imatmul__(self, *_, **__):
+        self._raise()
+
+    def __imod__(self, *_, **__):
+        self._raise()
+
+    def __imul__(self, *_, **__):
+        self._raise()
+
+    def __index__(self, *_, **__):
+        self._raise()
+
+    def __int__(self, *_, **__):
+        self._raise()
+
+    def __invert__(self, *_, **__):
+        self._raise()
+
+    def __ior__(self, *_, **__):
+        self._raise()
+
+    def __ipow__(self, *_, **__):
+        self._raise()
+
+    def __irshift__(self, *_, **__):
+        self._raise()
+
+    def __isub__(self, *_, **__):
+        self._raise()
+
+    def __iter__(self, *_, **__):
+        self._raise()
+
+    def __itruediv__(self, *_, **__):
+        self._raise()
+
+    def __ixor__(self, *_, **__):
+        self._raise()
+
+    def __le__(self, *_, **__):
+        self._raise()
+
+    def __lshift__(self, *_, **__):
+        self._raise()
+
+    def __lt__(self, *_, **__):
+        self._raise()
+
+    def __matmul__(self, *_, **__):
+        self._raise()
+
+    def __mod__(self, *_, **__):
+        self._raise()
+
+    def __mul__(self, *_, **__):
+        self._raise()
+
+    def __ne__(self, *_, **__):
+        self._raise()
+
+    def __neg__(self, *_, **__):
+        self._raise()
+
+    def __next__(self, *_, **__):
+        self._raise()
+
+    def __or__(self, *_, **__):
+        self._raise()
+
+    def __pos__(self, *_, **__):
+        self._raise()
+
+    def __pow__(self, *_, **__):
+        self._raise()
+
+    def __radd__(self, *_, **__):
+        self._raise()
+
+    def __rand__(self, *_, **__):
+        self._raise()
+
+    def __repr__(self, *_, **__):
+        self._raise()
+
+    def __rfloordiv__(self, *_, **__):
+        self._raise()
+
+    def __rlshift__(self, *_, **__):
+        self._raise()
+
+    def __rmatmul__(self, *_, **__):
+        self._raise()
+
+    def __rmod__(self, *_, **__):
+        self._raise()
+
+    def __rmul__(self, *_, **__):
+        self._raise()
+
+    def __ror__(self, *_, **__):
+        self._raise()
+
+    def __rpow__(self, *_, **__):
+        self._raise()
+
+    def __rrshift__(self, *_, **__):
+        self._raise()
+
+    def __rshift__(self, *_, **__):
+        self._raise()
+
+    def __rsub__(self, *_, **__):
+        self._raise()
+
+    def __rtruediv__(self, *_, **__):
+        self._raise()
+
+    def __rxor__(self, *_, **__):
+        self._raise()
+
+    def __set__(self, *_, **__):
+        self._raise()
+
+    def __setitem__(self, *_, **__):
+        self._raise()
+
+    def __str__(self, *_, **__):
+        self._raise()
+
+    def __sub__(self, *_, **__):
+        self._raise()
+
+    def __truediv__(self, *_, **__):
+        self._raise()
+
+    def __xor__(self, *_, **__):
+        self._raise()
+
+
 class _LazyErrorModule(ModuleType):
     """This module is a lazy error thrower. It is created when the module cannot
     be found so that import errors are deferred until attribute access.
@@ -40,8 +291,11 @@ class _LazyErrorModule(ModuleType):
         super().__init__(name)
         self.__path__ = None
 
-    def __getattr__(self, name: str):
-        raise ModuleNotFoundError(f"No module named '{self.__name__}'")
+    def __getattr__(self, name: str) -> _LazyErrorAttr:
+        # For special module attrs, return as if a stub module
+        if name in ["__file__", "__module__", "__doc__", "__cached__"]:
+            return None
+        return _LazyErrorAttr(self.__name__)
 
 
 class _LazyErrorLoader(importlib.abc.Loader):

--- a/import_tracker/lazy_import_errors.py
+++ b/import_tracker/lazy_import_errors.py
@@ -43,10 +43,17 @@ class _LazyErrorAttr(type):
         is raised rather than an opaque error about NEWOBJ not being a type.
     """
 
-    def __new__(cls, missing_module_name: str):
-        return super().__new__(cls, f"_LazyErrorAttr[{missing_module_name}]", (), {})
+    def __new__(cls, missing_module_name: str, bases=None, namespace=None):
+        # When this is used as a base class, we need to pass __classcell__
+        # through to type.__new__ to avoid a runtime warning.
+        new_namespace = {}
+        if isinstance(namespace, dict):
+            new_namespace["__classcell__"] = namespace.get("__classcell__")
+        return super().__new__(
+            cls, f"_LazyErrorAttr[{missing_module_name}]", (), new_namespace
+        )
 
-    def __init__(self, missing_module_name: str):
+    def __init__(self, missing_module_name: str, *_, **__):
         """Store the name of the attribute being accessed and the missing module"""
 
         def _raise(*_, **__):
@@ -72,6 +79,7 @@ class _LazyErrorAttr(type):
     #   __init__
     #   __len__
     #   __new__
+    #   __repr__
     #   __setattr__
     ##
     def __abs__(self, *_, **__):
@@ -222,9 +230,6 @@ class _LazyErrorAttr(type):
         self._raise()
 
     def __rand__(self, *_, **__):
-        self._raise()
-
-    def __repr__(self, *_, **__):
         self._raise()
 
     def __rfloordiv__(self, *_, **__):

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,6 +4,7 @@ alchemy-logging>=1.0.3
 PyYaml>=6.0
 # Testing
 pytest>=6.2.5
+pytest-asyncio>=0.17.0
 pytest-cov>=3.0.0
 # This is only used to validate the funky google namespace corner case
 protobuf==3.19.1

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -11,4 +11,5 @@ python3 -m pytest \
     --cov-report=term \
     --cov-report=html \
     --cov-fail-under=$FAIL_THRESH \
+    --asyncio-mode=strict \
     -W error "$@"


### PR DESCRIPTION
## Description

The goal of `lazy_import_errors` is to allow modules within a library to be imported cleanly, even if they have missing imports, and then defer those imports until their contents are used. One of the most common uses of a module, however, is to use an attribute from it _at import time_. This typically looks like inheriting from a class within that module, or accessing a constant, or something similar. With the previous implementation where the `ModuleNotFoundError` is raised on `__getattr__` for the missing module placeholder, these import-time usecases would raise at import time for the enclosing library.

This PR further defers missing module errors until the last possible moment: usage of attributes from within the missing module. It does so by introducing the `_LazyAttrError` object which will infinitely yield itself from `__getattr__` but will raise on _any_ other action (outside of a select few needed by the import mechanism).