### PR TITLE
Logging 8

### DIFF
--- a/import_tracker/__main__.py
+++ b/import_tracker/__main__.py
@@ -11,9 +11,14 @@ the import_module implementation when running in TRACKING mode.
 from typing import Set
 import argparse
 import importlib
+import inspect
 import json
+import logging
 import os
 import sys
+
+# Local
+from .log import log
 
 ## Implementation Details ######################################################
 
@@ -60,6 +65,51 @@ def _get_non_std_modules() -> Set[str]:
     }
 
 
+class _LoggingMetaFinder(importlib.abc.MetaPathFinder):
+    """Metafinder that simply logs the stack that is requesting the import of
+    the given package
+    """
+
+    def __init__(self, package_name: str):
+        """Construct with the name of the package being tracked"""
+        self._package_name = package_name
+        self._inspected_pacakges = []
+
+    def find_spec(self, fullname, path, *args, **kwargs):
+        """The primary metafinder inteface function"""
+        log.debug4("Looking for [fullname: %s, path: %s]", fullname, path)
+
+        # If this is the first time we've seen this top-level package, inspect
+        # the path
+        search_pkg_name = fullname.split(".")[0]
+        if search_pkg_name not in self._inspected_pacakges:
+            self._inspected_pacakges.append(search_pkg_name)
+
+            # Get the stack trace and prune out importlib
+            stack = inspect.stack()
+            non_importlib_mods = list(
+                filter(
+                    lambda x: x.split(".")[0] != "importlib",
+                    [frame.frame.f_globals["__name__"] for frame in stack],
+                )
+            )
+            log.debug3(
+                "[%s] Import stack for [%s]: %s",
+                self._package_name,
+                search_pkg_name,
+                non_importlib_mods,
+            )
+
+        return None
+
+
+def _setup_logging_meta_finder(package_name: str):
+    """Put a new metafinder at the front of the list that will simply log out
+    the stack that is requesting the import of a given package
+    """
+    sys.meta_path = [_LoggingMetaFinder(package_name)] + sys.meta_path
+
+
 ## Main ########################################################################
 
 
@@ -70,32 +120,57 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--name", "-n", help="Module name to import", required=True)
     parser.add_argument(
-        "--package", "-p", help="Package for relative imports", default=None
+        "--package",
+        "-p",
+        help="Package for relative imports",
+        default=None,
     )
     parser.add_argument(
-        "--indent", "-i", type=int, help="Indent for json printing", default=None
+        "--indent",
+        "-i",
+        type=int,
+        help="Indent for json printing",
+        default=None,
+    )
+    parser.add_argument(
+        "--log_level",
+        "-l",
+        type=int,
+        help="Log level",
+        default=logging.ERROR,
     )
     args = parser.parse_args()
 
+    # Set the level on the shared logger
+    logging.basicConfig(level=args.log_level)
+
+    # Inject the "tracking" finder that will report the stack that triggers each
+    # import if the log level is high enough
+    if args.log_level <= logging.DEBUG - 3:
+        _setup_logging_meta_finder(args.name)
+
     # Do the import
+    log.debug("Importing %s.%s", args.package, args.name)
     imported = importlib.import_module(args.name, package=args.package)
 
     # Get the set of non-standard modules after the import and filter out any
     # modules that are parents of the target module itself
     parent_mod_name = imported.__name__.split(".")[0]
+    log.debug2("Parent module name: %s", parent_mod_name)
+    non_std_modules = _get_non_std_modules()
+    log.debug3("Non standard modules: %s", non_std_modules)
     module_deps = sorted(
         list(
             filter(
                 lambda mod: mod != parent_mod_name and mod is not None,
-                _get_non_std_modules(),
+                non_std_modules,
             )
         )
     )
+    log.debug("Module deps for %s: %s", imported.__name__, module_deps)
 
     # Print out the json dump
-    print(
-        json.dumps({imported.__name__: sorted(list(module_deps))}, indent=args.indent)
-    )
+    print(json.dumps({imported.__name__: module_deps}, indent=args.indent))
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/import_tracker/import_tracker.py
+++ b/import_tracker/import_tracker.py
@@ -202,10 +202,11 @@ def _track_deps(name: str, package: Optional[str] = None):
     """
 
     # Run this package as a subprocess and collect the results
-    cmd = "{} -W ignore -m {} --name {}".format(
+    cmd = "{} -W ignore -m {} --name {} --log_level {}".format(
         sys.executable,
         sys.modules[__name__].__package__,
         name,
+        log.root.level,
     )
     if package is not None:
         cmd += f" --package {package}"

--- a/import_tracker/import_tracker.py
+++ b/import_tracker/import_tracker.py
@@ -188,6 +188,7 @@ class LazyModule(ModuleType):
         and then delegate
         """
         if self.__wrapped_module is None:
+            log.debug1("Triggering lazy import for %s.%s", self.__package, self.__name)
             self.__wrapped_module = importlib.import_module(
                 self.__name,
                 self.__package,
@@ -210,6 +211,7 @@ def _track_deps(name: str, package: Optional[str] = None):
     )
     if package is not None:
         cmd += f" --package {package}"
+    log.debug2("Spawning subprocess with command: %s", cmd)
     env = dict(copy.deepcopy(os.environ))
     env[MODE_ENV_VAR] = LAZY
     env["PYTHONPATH"] = ":".join(sys.path)

--- a/import_tracker/import_tracker.py
+++ b/import_tracker/import_tracker.py
@@ -20,6 +20,7 @@ import warnings
 
 # Local
 from .lazy_import_errors import lazy_import_errors
+from .log import log
 
 ## Public Globals ##############################################################
 
@@ -78,6 +79,9 @@ def set_static_tracker(fname: Optional[str] = None):
         )
 
     # Map the calling package name to the final file name in the global mapping of tracked modules
+    log.debug(
+        "Enabling static tracking for %s in file %s", calling_package.__name__, fname
+    )
     global _static_trackers
     _static_trackers[calling_package.__name__] = fname
 
@@ -93,6 +97,7 @@ def import_module(name: str, package: Optional[str] = None) -> ModuleType:
 
     # Get the current import mode
     import_mode = _get_import_mode()
+    log.debug2("Importing with mode %s", import_mode)
 
     # If not running in TRACKING mode, load the static tracker if available
     if import_mode in [PROACTIVE, LAZY, BEST_EFFORT]:

--- a/import_tracker/log.py
+++ b/import_tracker/log.py
@@ -1,0 +1,24 @@
+"""
+This module holds a shared logging instance handle to use in the other modules.
+This log handle has additional higher-order logging functions defined that align
+with the levels for alog (https://github.com/IBM/alchemy-logging).
+"""
+
+# Standard
+import logging
+
+log = logging.getLogger("IMPRT")
+
+# Add higher-order logging
+setattr(
+    log, "debug1", lambda *args, **kwargs: log.log(logging.DEBUG - 1, *args, **kwargs)
+)
+setattr(
+    log, "debug2", lambda *args, **kwargs: log.log(logging.DEBUG - 2, *args, **kwargs)
+)
+setattr(
+    log, "debug3", lambda *args, **kwargs: log.log(logging.DEBUG - 3, *args, **kwargs)
+)
+setattr(
+    log, "debug4", lambda *args, **kwargs: log.log(logging.DEBUG - 4, *args, **kwargs)
+)

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -5,6 +5,7 @@ Tests for the main entrypoint
 # Standard
 from contextlib import contextmanager
 import json
+import logging
 import sys
 
 # Third Party
@@ -74,3 +75,20 @@ def test_file_without_parent_path(capsys):
     # Just check the keys. The values are funky because of this being run from
     # within a test
     assert list(parsed_out.keys()) == ["google.protobuf"]
+
+
+def test_with_logging(capsys, LAZY_MODE):
+    """Run the main function with logging turned up and make sure the output is
+    not changed
+    """
+    with cli_args(
+        "--name", "sample_lib.submod1", "--log_level", str(logging.DEBUG - 3)
+    ):
+        main()
+    captured = capsys.readouterr()
+    assert captured.out
+    parsed_out = json.loads(captured.out)
+    assert list(parsed_out.keys()) == ["sample_lib.submod1"]
+    assert (set(parsed_out["sample_lib.submod1"]) - BASE_SYS_MODULES) == {
+        "conditional_deps"
+    }


### PR DESCRIPTION
## Description

Per the discussion in #8, this PR adds logging to the package using the built-in `logging` module. It also tries to follow conventions from [alog](https://github.com/IBM/alchemy-logging) by enabling low-level log functions beyond `debug` for highly detailed levels.

## Changes

* Add the `log` sub-module which defines the `Logger` for the library and decorates it with the lower-level log functions
* Add logging to various functions where helpful for debugging
* Add a new `MetaFinder` in the `__main__` when `debug3` or greater logging is enabled that helps trace where a given module is imported within a library

## Testing

* Full unit test coverage for new log lines