### PR TITLE
Handle side effect libraries

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
       hooks:
           - id: prettier
     - repo: https://github.com/psf/black
-      rev: 20.8b1
+      rev: 22.3.0
       hooks:
           - id: black
             exclude: imports

--- a/import_tracker/__main__.py
+++ b/import_tracker/__main__.py
@@ -469,6 +469,7 @@ def main():
                         module_name=internal_downstream,
                         log_level=log_level,
                         recursive=False,
+                        side_effect_modules=args.side_effect_modules,
                     )
                 )
 
@@ -487,6 +488,7 @@ def main():
                             module_name=internal_downstream,
                             log_level=log_level,
                             recursive=False,
+                            side_effect_modules=args.side_effect_modules,
                         )
                     )
                 # This is useful for catching errors caused by unexpected corner

--- a/import_tracker/__main__.py
+++ b/import_tracker/__main__.py
@@ -17,7 +17,7 @@ python -m import_tracker --name .my_sub_module --package my_library
 # Standard
 from concurrent.futures import ThreadPoolExecutor
 from types import ModuleType
-from typing import Optional, Set
+from typing import List, Optional, Set
 import argparse
 import cmath
 import importlib
@@ -206,14 +206,22 @@ class ImportTrackerMetaFinder(importlib.abc.MetaPathFinder):
         used during the import phase of a library at runtime!
     """
 
-    def __init__(self, tracked_module: str):
+    def __init__(
+        self, tracked_module: str, side_effect_modules: Optional[List[str]] = None
+    ):
         """Initialize with the name of the package being tracked
 
         Args:
             tracked_module:  str
                 The name of the module (may be nested) being tracked
+            side_effect_modules:  Optional[List[str]]
+                Some libraries rely on certain import-time side effects in order
+                to perform required import tasks (e.g. global singleton
+                registries). These modules will be allowed to import regardless
+                of where they fall relative to the targeted module.
         """
         self._tracked_module = tracked_module
+        self._side_effect_modules = side_effect_modules or []
         self._tracked_module_parts = tracked_module.split(".")
         self._enabled = True
         self._starting_modules = set(sys.modules.keys())
@@ -241,6 +249,12 @@ class ImportTrackerMetaFinder(importlib.abc.MetaPathFinder):
                 import is on the critical path, None will be returned to defer
                 to the rest of the "real" finders.
         """
+
+        # If this module fullname is one of the modules with known side-effects,
+        # let it fall through
+        if fullname in self._side_effect_modules:
+            log.debug("Allowing import of side-effect module [%s]", fullname)
+            return None
 
         # If this finder is enabled and the requested import is not the target,
         # defer it with a lazy module
@@ -389,6 +403,13 @@ def main():
         help="Number of workers to spawn when recursing",
         default=0,
     )
+    parser.add_argument(
+        "--side_effect_modules",
+        "-s",
+        nargs="*",
+        default=None,
+        help="Modules with known import-time side effect which should always be allowed to import",
+    )
     args = parser.parse_args()
 
     # Mark the environment as tracking mode so that any lazy import errors are
@@ -410,7 +431,7 @@ def main():
         full_module_name = f"{args.package}{args.name}"
 
     # Create the tracking meta finder
-    tracker_finder = ImportTrackerMetaFinder(full_module_name)
+    tracker_finder = ImportTrackerMetaFinder(full_module_name, args.side_effect_modules)
     sys.meta_path = [tracker_finder] + sys.meta_path
 
     # Do the import

--- a/import_tracker/import_tracker.py
+++ b/import_tracker/import_tracker.py
@@ -26,6 +26,7 @@ def track_module(
     log_level: Optional[int] = None,
     recursive: bool = False,
     num_jobs: int = 0,
+    side_effect_modules: Optional[List[str]] = None,
 ) -> Dict[str, List[str]]:
     """This function executes the tracking of a single module by launching a
     subprocess to execute this module against the target module. The
@@ -45,6 +46,11 @@ def track_module(
             module
         num_jobs:  int
             The number of concurrent jobs to run when recursing
+        side_effect_modules:  Optional[List[str]]
+            Some libraries rely on certain import-time side effects in order to
+            perform required import tasks (e.g. global singleton registries).
+            These modules will be allowed to import regardless of where they
+            fall relative to the targeted module.
 
     Returns:
         import_mapping:  Dict[str, List[str]]
@@ -74,6 +80,8 @@ def track_module(
         cmd += f" --package {package_name}"
     if recursive:
         cmd += " --recursive"
+    if side_effect_modules:
+        cmd += " --side_effect_modules " + " ".join(side_effect_modules)
 
     # Launch the process
     proc = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE, env=env)

--- a/import_tracker/setup_tools.py
+++ b/import_tracker/setup_tools.py
@@ -22,6 +22,7 @@ def parse_requirements(
     requirements_file: str,
     library_name: str,
     extras_modules: Optional[List[str]] = None,
+    **kwargs,
 ) -> Tuple[List[str], Dict[str, List[str]]]:
     """This helper uses the lists of required modules and parameters for the
     given library to produce requirements and the extras_require dict.
@@ -34,6 +35,8 @@ def parse_requirements(
         extras_modules:  Optional[List[str]]
             List of module names that should be used to generate extras_require
             sets
+        **kwargs:
+            Additional keyword arguments to pass through to track_module
 
     Returns:
         requirements:  List[str]
@@ -52,7 +55,7 @@ def parse_requirements(
     log.debug("Requirements: %s", requirements)
 
     # Get the set of required modules for each of the listed extras modules
-    library_import_mapping = track_module(library_name, recursive=True)
+    library_import_mapping = track_module(library_name, recursive=True, **kwargs)
 
     # If no extras_modules are given, track them all
     if not extras_modules:

--- a/test/sample_libs/side_effects/__init__.py
+++ b/test/sample_libs/side_effects/__init__.py
@@ -1,0 +1,12 @@
+"""
+This sample module is an example of a library which uses import-time side
+effects. It does so by having `global_thing` modify a central object on the base
+module and then requiring that step in the import of `mod`.
+"""
+
+GLOBAL_RESOURCE = []
+
+# Local
+# Import mod second which requires GLOBAL_RESOURCE to be populated
+# Import global_thing first to populate GLOBAL_RESOURCE
+from . import global_thing, mod

--- a/test/sample_libs/side_effects/global_thing.py
+++ b/test/sample_libs/side_effects/global_thing.py
@@ -1,0 +1,8 @@
+"""
+This module is responsible for implementing the import-time side effect
+"""
+
+# Local
+from . import GLOBAL_RESOURCE
+
+GLOBAL_RESOURCE.append(1)

--- a/test/sample_libs/side_effects/mod.py
+++ b/test/sample_libs/side_effects/mod.py
@@ -1,0 +1,8 @@
+"""
+This module requires that GLOBAL_RESOURCE has at least one valid element
+"""
+
+# Local
+from . import GLOBAL_RESOURCE
+
+assert GLOBAL_RESOURCE, "I need my side effects!"

--- a/test/test_lazy_import_errors.py
+++ b/test/test_lazy_import_errors.py
@@ -152,7 +152,7 @@ def test_lazy_import_error_with_from():
         lambda: Baz(),
         lambda: Baz + 1,
         lambda: Baz * 2,
-        lambda: Baz ** 2,
+        lambda: Baz**2,
         lambda: Baz @ 2,
         lambda: Baz - 1,
         lambda: 1 - Baz,

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -138,3 +138,33 @@ def test_lib_with_lazy_imports(capsys):
     assert captured.out
     parsed_out = json.loads(captured.out)
     assert "lazy_import_errors" in parsed_out
+
+
+def test_lib_with_side_effect_imports():
+    """Make sure that a library with import-time side effects works when
+    specifying the --side_effect_modules argument and fails without it
+    """
+
+    # Expect failure without the argument
+    with cli_args("--name", "side_effects.mod"):
+        with pytest.raises(AssertionError):
+            main()
+
+    # Expect success with the argument
+    with cli_args(
+        "--name",
+        "side_effects.mod",
+        "--side_effect_modules",
+        "side_effects.global_thing",
+    ):
+        main()
+
+    # Ensure that the argument is passed recursively
+    with cli_args(
+        "--name",
+        "side_effects",
+        "--side_effect_modules",
+        "side_effects.global_thing",
+        "--recursive",
+    ):
+        main()

--- a/test/test_setup_tools.py
+++ b/test/test_setup_tools.py
@@ -111,3 +111,21 @@ def test_parse_requirements_unknown_extras():
         # Make sure the assertion is tripped
         with pytest.raises(AssertionError):
             parse_requirements(requirements_file.name, "sample_lib", ["foobar"])
+
+
+def test_parse_requirements_with_side_effects():
+    """Make sure that side_effect_modules can be passed through to allow for
+    successful parsing
+    """
+    with tempfile.NamedTemporaryFile("w") as requirements_file:
+        # Make a requirements file that looks normal
+        requirements_file.write("\n".join(sample_lib_requirements))
+        requirements_file.flush()
+
+        # Parse the reqs for "side_effects". We only care that this doesn't
+        # raise, so there's no validation of the results.
+        parse_requirements(
+            requirements_file=requirements_file.name,
+            library_name="side_effects",
+            side_effect_modules=["side_effects.global_thing"],
+        )


### PR DESCRIPTION
## Problem Description

Though generally an anti-pattern, many libraries use [side effects](https://en.wikipedia.org/wiki/Side_effect_(computer_science)) at import time to handle global configuration tasks. I'm guilty of doing this often! This causes issues for `import_tracker` because downstream modules from the module with the global configuration often rely on the fact that the side-effect module is imported beforehand and that therefore the global configuration is in place. By default with `import_tracker`, these side-effect modules are configured as deferred imports and since the downstream libraries often don't explicitly import them, they never get imported and their side-effects never get triggered.

It would be nice to simply say that "we don't support this" but it would also severely limit the usability of this library. Also, the primary target library that this was written for (`watson_nlp`) does this for multiple valid reasons! As such, we find ourselves here.

## Solution

The "best" solution is for the library author to avoid using side-effect imports. When this is impossible or impractical, this PR fills the gap by allowing users to specify `side_effect_modules` that should _always_ be allowed to import regardless of whether they fall into the import tree for the target module.

**WARNING**: This is not a perfect solution! By specifying a part of a library as a `side_effect_module`, it effectively makes all dependencies of that module univeral.

## Changes

* Add `--side_effect_modules` argument to `__main__`
* Allow `side_effect_modules` to be passed to `ImportTrackerMetaFinder` and always let them through `find_spec`
* Add `side_effect_modules` argument to `track_module` and use it when recursing in `__main__`
* Allow arbitrary `**kwargs` to pass through `parse_requirements` so that `side_effect_modules` can be passed to `parse_requirements`

## Testing

* Unit tests for everything
* Validated that this gets us past the global JVM problem in `watson_nlp`