### PR TITLE
Limited recursion 25

### DIFF
--- a/import_tracker/import_tracker.py
+++ b/import_tracker/import_tracker.py
@@ -27,6 +27,7 @@ def track_module(
     recursive: bool = False,
     num_jobs: int = 0,
     side_effect_modules: Optional[List[str]] = None,
+    submodules: Optional[List[str]] = None,
 ) -> Dict[str, List[str]]:
     """This function executes the tracking of a single module by launching a
     subprocess to execute this module against the target module. The
@@ -51,6 +52,8 @@ def track_module(
             perform required import tasks (e.g. global singleton registries).
             These modules will be allowed to import regardless of where they
             fall relative to the targeted module.
+        submodules:  Optional[List[str]]
+            List of sub-modules to recurse on (only used when recursive set)
 
     Returns:
         import_mapping:  Dict[str, List[str]]
@@ -82,6 +85,8 @@ def track_module(
         cmd += " --recursive"
     if side_effect_modules:
         cmd += " --side_effect_modules " + " ".join(side_effect_modules)
+    if submodules:
+        cmd += " --submodules " + " ".join(submodules)
 
     # Launch the process
     proc = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE, env=env)

--- a/import_tracker/setup_tools.py
+++ b/import_tracker/setup_tools.py
@@ -54,6 +54,11 @@ def parse_requirements(
         }
     log.debug("Requirements: %s", requirements)
 
+    # If extras_modules are given, use them as the submodules list
+    if extras_modules:
+        log.debug2("Only recursing on extras modules: %s", extras_modules)
+        kwargs["submodules"] = extras_modules
+
     # Get the set of required modules for each of the listed extras modules
     library_import_mapping = track_module(library_name, recursive=True, **kwargs)
 

--- a/test/test_import_tracker.py
+++ b/test/test_import_tracker.py
@@ -79,3 +79,16 @@ def test_track_module_with_log_level():
         "sample_lib.submod1", log_level="error"
     )
     assert sample_lib_mapping == {"sample_lib.submod1": ["conditional_deps"]}
+
+
+def test_track_module_with_limited_submodules():
+    """Test that the submodules arg can be passed through"""
+    sample_lib_mapping = import_tracker.track_module(
+        "sample_lib",
+        recursive=True,
+        submodules=["sample_lib.submod1"],
+    )
+    assert sample_lib_mapping == {
+        "sample_lib": sorted(["conditional_deps", "alog", "yaml"]),
+        "sample_lib.submod1": ["conditional_deps"],
+    }

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -168,3 +168,33 @@ def test_lib_with_side_effect_imports():
         "--recursive",
     ):
         main()
+
+
+def test_with_limited_submodules(capsys):
+    """Make sure that when a list of submodules is given, the recursion only
+    applies to those submodules.
+    """
+    with cli_args(
+        "--name",
+        "sample_lib",
+        "--recursive",
+        "--submodules",
+        "sample_lib.submod1",
+    ):
+        main()
+    captured = capsys.readouterr()
+    assert captured.out
+    parsed_out = json.loads(captured.out)
+    assert list(parsed_out.keys()) == ["sample_lib", "sample_lib.submod1"]
+
+
+def test_error_submodules_without_recursive():
+    """Make sure an error is raised when submodules given without recursive"""
+    with cli_args(
+        "--name",
+        "sample_lib",
+        "--submodules",
+        "sample_lib.submod1",
+    ):
+        with pytest.raises(ValueError):
+            main()


### PR DESCRIPTION
## Description

This PR adds a new `--submodules` arg to `main` (and a corresponding `submodules` arg to `track_modules`) that limits which submodules will be recursed on. It also uses the `extras_modules` arg to `parse_requirements` as `submodules` to avoid unnecessary work.

## Related Issues

Closes #25 