### PR TITLE
Track import stack 27

### DIFF
--- a/import_tracker/import_tracker.py
+++ b/import_tracker/import_tracker.py
@@ -28,6 +28,7 @@ def track_module(
     num_jobs: int = 0,
     side_effect_modules: Optional[List[str]] = None,
     submodules: Optional[List[str]] = None,
+    track_import_stack: bool = False,
 ) -> Dict[str, List[str]]:
     """This function executes the tracking of a single module by launching a
     subprocess to execute this module against the target module. The
@@ -54,6 +55,8 @@ def track_module(
             fall relative to the targeted module.
         submodules:  Optional[List[str]]
             List of sub-modules to recurse on (only used when recursive set)
+        track_import_stack:  bool
+            Store the stack trace of imports belonging to the tracked module
 
     Returns:
         import_mapping:  Dict[str, List[str]]
@@ -87,6 +90,8 @@ def track_module(
         cmd += " --side_effect_modules " + " ".join(side_effect_modules)
     if submodules:
         cmd += " --submodules " + " ".join(submodules)
+    if track_import_stack:
+        cmd += " --track_import_stack"
 
     # Launch the process
     proc = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE, env=env)

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -6,6 +6,7 @@ Tests for the main entrypoint
 from contextlib import contextmanager
 import json
 import logging
+import os
 import sys
 
 # Third Party
@@ -225,15 +226,22 @@ def test_import_stack_tracking(capsys):
     }
 
     # Check one of the stacks to make sure it's correct
+    test_lib_dir = os.path.realpath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "sample_libs",
+            "inter_mod_deps",
+        )
+    )
     assert parsed_out["inter_mod_deps.submod2"] == {
         "alog": [
             {
-                "filename": "/Users/ghart/Projects/github/IBM/import-tracker/test/sample_libs/inter_mod_deps/submod1/__init__.py",
+                "filename": f"{test_lib_dir}/submod1/__init__.py",
                 "lineno": 6,
                 "code_context": ["import alog"],
             },
             {
-                "filename": "/Users/ghart/Projects/github/IBM/import-tracker/test/sample_libs/inter_mod_deps/__init__.py",
+                "filename": f"{test_lib_dir}/__init__.py",
                 "lineno": 17,
                 "code_context": [
                     "from . import submod1, submod2, submod3, submod4, submod5"
@@ -242,12 +250,12 @@ def test_import_stack_tracking(capsys):
         ],
         "yaml": [
             {
-                "filename": "/Users/ghart/Projects/github/IBM/import-tracker/test/sample_libs/inter_mod_deps/submod2/__init__.py",
+                "filename": f"{test_lib_dir}/submod2/__init__.py",
                 "lineno": 6,
                 "code_context": ["import yaml"],
             },
             {
-                "filename": "/Users/ghart/Projects/github/IBM/import-tracker/test/sample_libs/inter_mod_deps/__init__.py",
+                "filename": f"{test_lib_dir}/__init__.py",
                 "lineno": 17,
                 "code_context": [
                     "from . import submod1, submod2, submod3, submod4, submod5"


### PR DESCRIPTION
## Description

This PR introduces a new argument to `main` and `track_module` that allows the output to contain stack trace information about where a given dependent import is coming from within the target library.

## Related Issues

Closes #27 

## Changes

* Move core logic of `ImportTrackerMetaFinder.find_spec` into a detail function `ImportTrackerMetaFinder._find_spec`
* Wrap `ImportTrackerMetaFinder._find_spec` in `ImportTrackerMetaFinder.find_spec` to optionally store a stack trace when an import is allowed through
* Plumb the arguments through `track_module`

## Testing

* Full unit test coverate

## Open Issues

* https://github.com/IBM/import-tracker/issues/31