### PR TITLE
Custom import errors 29

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ with lazy_import_errors():
     from . import widgets
 ```
 
+When using lazy import errors, there are two ways to customize the error message that is raised when a failed import is used:
+
+1.  1. The `get_extras_modules` argument takes a function which returns a `Set[str]` of the module names that are tracked as extras. If the import error is triggered within a module that is managed as an extras set, the error message is updated to include instructions on which extras set needs to be installed.
+
+2.  The `make_error_message` argument allows the caller to specify a fully custom error message generation function.
+
 ### Using `setup_tools.parse_requirements`
 
 To take advantage of the automatic dependency parsing when building a package, the `setup.py` would look like the following:

--- a/import_tracker/constants.py
+++ b/import_tracker/constants.py
@@ -6,4 +6,4 @@ Shared constants across the various parts of the library
 import sys
 
 # The name of this package (import_tracker)
-THIS_PACKAGE = sys.modules[__name__].__package__.split(".")[0]
+THIS_PACKAGE = sys.modules[__name__].__package__.partition(".")[0]

--- a/test/sample_libs/missing_dep/__init__.py
+++ b/test/sample_libs/missing_dep/__init__.py
@@ -1,0 +1,15 @@
+"""
+This sample lib intentionally implements a bad import so that it can be used to
+test lazy import errors
+"""
+# Local
+import import_tracker
+
+
+def get_extras_modules():
+    return {"missing_dep.mod"}
+
+
+with import_tracker.lazy_import_errors(get_extras_modules=get_extras_modules):
+    # Local
+    from . import mod, other

--- a/test/sample_libs/missing_dep/mod.py
+++ b/test/sample_libs/missing_dep/mod.py
@@ -1,0 +1,10 @@
+"""
+This sub-module actually does the bad import
+"""
+
+# Third Party
+import foobar
+
+
+def use_foobar():
+    foobar.doit()

--- a/test/sample_libs/missing_dep/other.py
+++ b/test/sample_libs/missing_dep/other.py
@@ -1,0 +1,9 @@
+"""
+This module also does a bad import, but isn't "tracked as an extra"
+"""
+# Third Party
+import bazbat
+
+
+def use_bazbat():
+    bazbat.doit()

--- a/test/test_lazy_import_errors.py
+++ b/test/test_lazy_import_errors.py
@@ -318,3 +318,20 @@ def test_lazy_import_error_infinite_attrs():
         from foo.bar import Baz
 
         assert Baz.bat is Baz
+
+
+def test_lazy_import_error_custom_error_msg():
+    """Make sure that the lazy_import_errors context manager can be configured
+    with a custom function for creating the error message.
+    """
+    custom_error_message = "This is a custom message!"
+
+    def make_error_msg(*_, **__):
+        return custom_error_message
+
+    with import_tracker.lazy_import_errors(make_error_msg):
+        # Third Party
+        from foo.bar import Baz
+
+    with pytest.raises(ModuleNotFoundError, match=custom_error_message):
+        Baz()

--- a/test/test_lazy_import_errors.py
+++ b/test/test_lazy_import_errors.py
@@ -329,9 +329,44 @@ def test_lazy_import_error_custom_error_msg():
     def make_error_msg(*_, **__):
         return custom_error_message
 
-    with import_tracker.lazy_import_errors(make_error_msg):
+    with import_tracker.lazy_import_errors(make_error_message=make_error_msg):
         # Third Party
         from foo.bar import Baz
 
     with pytest.raises(ModuleNotFoundError, match=custom_error_message):
         Baz()
+
+
+def test_lazy_import_error_get_extras_modules():
+    """Make sure that the lazy_import_errors context manager can be configured
+    with a get_extras_modules function and perform the custom error message
+    creation internally.
+    """
+    # Third Party
+    import missing_dep
+
+    # Using foobar inside missing_dep.mod should catch the custom error
+    with pytest.raises(
+        ModuleNotFoundError,
+        match=r".*pip install missing_dep\[missing_dep.mod\].*",
+    ):
+        missing_dep.mod.use_foobar()
+
+    # Using bazbat inside missing_dep.other should have the standard error since
+    # missing_dep.other is not tracked as an extra
+    with pytest.raises(
+        ModuleNotFoundError,
+        match="No module named 'bazbat'",
+    ):
+        missing_dep.other.use_bazbat()
+
+
+def test_lazy_import_error_mutually_exclusive_args():
+    """Make sure the args to lazy_import_errors are mutually exclusive"""
+    with pytest.raises(TypeError):
+        with import_tracker.lazy_import_errors(
+            make_error_message=1,
+            get_extras_modules=2,
+        ):
+            # Third Party
+            import foobar


### PR DESCRIPTION
## Related Issues

Closes #29 

## Description

This PR introduces two new ways to customize the errors emitted when using `lazy_import_errors`:

1. The `get_extras_modules` argument takes a function which returns a `Set[str]` of the module names that are tracked as extras. If the `_LazyErrorAttr` triggers from within a stack that includes one of these extras modules, the error message is updated to include instructions on which extras set needs to be installed.
2. The `make_error_message` argument allows the user to specify a fully custom error message generation function

## Testing

* Unit test coverage
* Validated with watson_nlp