### PR TITLE
🐛 Single extras 38

### DIFF
--- a/import_tracker/setup_tools.py
+++ b/import_tracker/setup_tools.py
@@ -94,6 +94,14 @@ def parse_requirements(
     missing_extras_modules = [
         mod for mod in extras_modules if mod not in library_import_mapping
     ]
+    if extras_modules_post_filter is not None:
+        missing_extras_modules.extend(
+            [
+                mod
+                for mod in extras_modules_post_filter
+                if mod not in library_import_mapping
+            ]
+        )
     assert (
         not missing_extras_modules
     ), f"No tracked imports found for: {missing_extras_modules}"

--- a/test/sample_libs/single_extra/__init__.py
+++ b/test/sample_libs/single_extra/__init__.py
@@ -1,0 +1,6 @@
+# First Party
+import alog
+
+# Local
+from . import extra
+from .not_extra import foo

--- a/test/sample_libs/single_extra/extra.py
+++ b/test/sample_libs/single_extra/extra.py
@@ -1,0 +1,2 @@
+# Third Party
+import yaml

--- a/test/sample_libs/single_extra/not_extra.py
+++ b/test/sample_libs/single_extra/not_extra.py
@@ -1,0 +1,2 @@
+def foo():
+    print("Hello Foo!")

--- a/test/test_setup_tools.py
+++ b/test/test_setup_tools.py
@@ -142,3 +142,17 @@ def test_parse_requirements_bad_requirements_type():
     # Make sure the assertion is tripped
     with pytest.raises(ValueError):
         parse_requirements({"foo": "bar"}, "sample_lib", ["foobar"])
+
+
+def test_single_extras_module():
+    """Make sure that for a library with a single extras module and a non-zero
+    set of non-extra modules, the deps for the extra module are correctly
+    allocated.
+    """
+    requirements, extras_require = parse_requirements(
+        ["alchemy-logging", "PyYaml"],
+        "single_extra",
+        ["single_extra.extra"],
+    )
+    assert requirements == ["alchemy-logging"]
+    assert extras_require == {"single_extra.extra": ["PyYaml"]}


### PR DESCRIPTION
## Description

This PR addresses #38. It is a partial solution that handles the case where there is a single extras module AND there are one-or-more non-extras modules. In the case where there's a single extras module and no other non-extras modules, the dependencies from the extras module will still be allocated to the global set because the dependency relationship with the parent has no alternate traversals of the import tree, so there is no separability between the child and the parent. This case should be _extremely_ rare, though, as using `import_tracker` in this case would be wildly overkill for such a toy example.

## Changes

* If there is only a single `extras_module`, perform the full recursive tracking rather than limiting to just the single extras module
* If a single `extras_module` was given, filter the output `extras_require` dict to only include the requested module

## Implications

* This could cause performance degradation in the case of a large library with lots of non-extras modules and a single extras module as it will perform extra work to track all non-extras modules just to provide separability from the target extras