### PR TITLE
C math builtin 40

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,3 +39,45 @@ jobs:
               run: docker build . --target=test
               env:
                   PYTHON_VERSION: "3.10"
+
+    # Builds to validate Ubuntu PPA
+    build-37-ppa:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - name: Run unit tests
+              run: |
+                  docker build . -f ppa.dockerfile -t python-ppa
+                  docker build . --target=test --build-arg BASE_IMAGE=python-ppa
+              env:
+                  PYTHON_VERSION: "3.7"
+    build-38-ppa:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - name: Run unit tests
+              run: |
+                  docker build . -f ppa.dockerfile -t python-ppa
+                  docker build . --target=test --build-arg BASE_IMAGE=python-ppa
+              env:
+                  PYTHON_VERSION: "3.8"
+    build-39-ppa:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - name: Run unit tests
+              run: |
+                  docker build . -f ppa.dockerfile -t python-ppa
+                  docker build . --target=test --build-arg BASE_IMAGE=python-ppa
+              env:
+                  PYTHON_VERSION: "3.9"
+    build-31-ppa0:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - name: Run unit tests
+              run: |
+                  docker build . -f ppa.dockerfile -t python-ppa
+                  docker build . --target=test --build-arg BASE_IMAGE=python-ppa
+              env:
+                  PYTHON_VERSION: "3.10"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
         steps:
             - uses: actions/checkout@v2
             - name: Run unit tests
-              run: docker build . --target=test
+              run: docker build . --target=test --build-arg PYTHON_VERSION=${PYTHON_VERSION}
               env:
                   PYTHON_VERSION: "3.7"
     build-38:
@@ -20,7 +20,7 @@ jobs:
         steps:
             - uses: actions/checkout@v2
             - name: Run unit tests
-              run: docker build . --target=test
+              run: docker build . --target=test --build-arg PYTHON_VERSION=${PYTHON_VERSION}
               env:
                   PYTHON_VERSION: "3.8"
     build-39:
@@ -28,7 +28,7 @@ jobs:
         steps:
             - uses: actions/checkout@v2
             - name: Run unit tests
-              run: docker build . --target=test
+              run: docker build . --target=test --build-arg PYTHON_VERSION=${PYTHON_VERSION}
               env:
                   PYTHON_VERSION: "3.9"
     build-310:
@@ -36,7 +36,7 @@ jobs:
         steps:
             - uses: actions/checkout@v2
             - name: Run unit tests
-              run: docker build . --target=test
+              run: docker build . --target=test --build-arg PYTHON_VERSION=${PYTHON_VERSION}
               env:
                   PYTHON_VERSION: "3.10"
 
@@ -47,7 +47,7 @@ jobs:
             - uses: actions/checkout@v2
             - name: Run unit tests
               run: |
-                  docker build . -f ppa.dockerfile -t python-ppa
+                  docker build . -f ppa.dockerfile -t python-ppa --build-arg PYTHON_VERSION=${PYTHON_VERSION}
                   docker build . --target=test --build-arg BASE_IMAGE=python-ppa
               env:
                   PYTHON_VERSION: "3.7"
@@ -57,7 +57,7 @@ jobs:
             - uses: actions/checkout@v2
             - name: Run unit tests
               run: |
-                  docker build . -f ppa.dockerfile -t python-ppa
+                  docker build . -f ppa.dockerfile -t python-ppa --build-arg PYTHON_VERSION=${PYTHON_VERSION}
                   docker build . --target=test --build-arg BASE_IMAGE=python-ppa
               env:
                   PYTHON_VERSION: "3.8"
@@ -67,7 +67,7 @@ jobs:
             - uses: actions/checkout@v2
             - name: Run unit tests
               run: |
-                  docker build . -f ppa.dockerfile -t python-ppa
+                  docker build . -f ppa.dockerfile -t python-ppa --build-arg PYTHON_VERSION=${PYTHON_VERSION}
                   docker build . --target=test --build-arg BASE_IMAGE=python-ppa
               env:
                   PYTHON_VERSION: "3.9"
@@ -77,7 +77,7 @@ jobs:
             - uses: actions/checkout@v2
             - name: Run unit tests
               run: |
-                  docker build . -f ppa.dockerfile -t python-ppa
+                  docker build . -f ppa.dockerfile -t python-ppa --build-arg PYTHON_VERSION=${PYTHON_VERSION}
                   docker build . --target=test --build-arg BASE_IMAGE=python-ppa
               env:
                   PYTHON_VERSION: "3.10"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
             - name: Run unit tests
               run: |
                   docker build . -f ppa.dockerfile -t python-ppa --build-arg PYTHON_VERSION=${PYTHON_VERSION}
-                  docker build . --target=test --build-arg BASE_IMAGE=python-ppa
+                  docker build . --target=test --build-arg BASE_IMAGE=python-ppa --build-arg RUN_FMT=false
               env:
                   PYTHON_VERSION: "3.7"
     build-38-ppa:
@@ -58,7 +58,7 @@ jobs:
             - name: Run unit tests
               run: |
                   docker build . -f ppa.dockerfile -t python-ppa --build-arg PYTHON_VERSION=${PYTHON_VERSION}
-                  docker build . --target=test --build-arg BASE_IMAGE=python-ppa
+                  docker build . --target=test --build-arg BASE_IMAGE=python-ppa --build-arg RUN_FMT=false
               env:
                   PYTHON_VERSION: "3.8"
     build-39-ppa:
@@ -68,7 +68,7 @@ jobs:
             - name: Run unit tests
               run: |
                   docker build . -f ppa.dockerfile -t python-ppa --build-arg PYTHON_VERSION=${PYTHON_VERSION}
-                  docker build . --target=test --build-arg BASE_IMAGE=python-ppa
+                  docker build . --target=test --build-arg BASE_IMAGE=python-ppa --build-arg RUN_FMT=false
               env:
                   PYTHON_VERSION: "3.9"
     build-31-ppa0:
@@ -78,6 +78,6 @@ jobs:
             - name: Run unit tests
               run: |
                   docker build . -f ppa.dockerfile -t python-ppa --build-arg PYTHON_VERSION=${PYTHON_VERSION}
-                  docker build . --target=test --build-arg BASE_IMAGE=python-ppa
+                  docker build . --target=test --build-arg BASE_IMAGE=python-ppa --build-arg RUN_FMT=false
               env:
                   PYTHON_VERSION: "3.10"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,7 +71,7 @@ jobs:
                   docker build . --target=test --build-arg BASE_IMAGE=python-ppa --build-arg RUN_FMT=false
               env:
                   PYTHON_VERSION: "3.9"
-    build-31-ppa0:
+    build-310-ppa:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@
 # This phase sets up dependencies for the other phases
 ##
 ARG PYTHON_VERSION=3.7
-FROM python:${PYTHON_VERSION}-slim as base
+ARG BASE_IMAGE=python:${PYTHON_VERSION}-slim
+FROM ${BASE_IMAGE} as base
 
 # This image is only for building, so we run as root
 WORKDIR /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN true && \
 ##
 FROM base as test
 COPY . /src
+ARG RUN_FMT="true"
 RUN true && \
     ./scripts/run_tests.sh && \
     RELEASE_DRY_RUN=true RELEASE_VERSION=0.0.0 \

--- a/import_tracker/__main__.py
+++ b/import_tracker/__main__.py
@@ -49,7 +49,7 @@ def _get_dylib_dir():
     sample_dylib = None
     if all_mod_paths:
         sample_dylib = all_mod_paths[0]
-    else:
+    else:  # pragma: no cover
         # If not found with the above, look through libraries that are known to
         # sometimes be packaged as compiled extensions
         #
@@ -69,7 +69,7 @@ def _get_dylib_dir():
 
     # If all else fails, we'll just return a sentinel string. This will fail to
     # match in the below check for builtin modules
-    return "BADPATH"
+    return "BADPATH"  # pragma: no cover
 
 
 # The path where global modules are found

--- a/import_tracker/__main__.py
+++ b/import_tracker/__main__.py
@@ -19,7 +19,6 @@ from concurrent.futures import ThreadPoolExecutor
 from types import ModuleType
 from typing import Dict, List, Optional, Set, Union
 import argparse
-import cmath
 import importlib
 import inspect
 import json
@@ -36,9 +35,46 @@ from .log import log
 
 ## Implementation Details ######################################################
 
+
+def _get_dylib_dir():
+    """Differnet versions/builds of python manage different builtin libraries as
+    "builtins" versus extensions. As such, we need some heuristics to try to
+    find the base directory that holds shared objects from the standard library.
+    """
+    is_dylib = lambda x: x is not None and (x.endswith(".so") or x.endswith(".dylib"))
+    all_mod_paths = list(
+        filter(is_dylib, (getattr(mod, "__file__", "") for mod in sys.modules.values()))
+    )
+    # If there's any dylib found, return the parent directory
+    sample_dylib = None
+    if all_mod_paths:
+        sample_dylib = all_mod_paths[0]
+    else:
+        # If not found with the above, look through libraries that are known to
+        # sometimes be packaged as compiled extensions
+        #
+        # NOTE: This code may be unnecessary, but it is intended to catch future
+        #   cases where the above does not yield results
+        #
+        # More names can be added here as needed
+        for lib_name in ["cmath"]:
+            lib = importlib.import_module(lib_name)
+            fname = getattr(lib, "__file__", None)
+            if is_dylib(fname):
+                sample_dylib = fname
+                break
+
+    if sample_dylib is not None:
+        return os.path.realpath(os.path.dirname(sample_dylib))
+
+    # If all else fails, we'll just return a sentinel string. This will fail to
+    # match in the below check for builtin modules
+    return "BADPATH"
+
+
 # The path where global modules are found
 _std_lib_dir = os.path.realpath(os.path.dirname(os.__file__))
-_std_dylib_dir = os.path.realpath(os.path.dirname(cmath.__file__))
+_std_dylib_dir = _get_dylib_dir()
 
 
 def _get_import_parent_path(mod) -> str:

--- a/ppa.dockerfile
+++ b/ppa.dockerfile
@@ -9,11 +9,14 @@ FROM ubuntu:18.04
 
 ARG PYTHON_VERSION=3.7
 RUN true && \
-    apt update && \
-    apt install software-properties-common -y && \
+    apt-get update && \
+    apt-get install software-properties-common -y && \
     add-apt-repository ppa:deadsnakes/ppa -y && \
-    apt update && \
-    apt install python${PYTHON_VERSION} python3-pip -y && \
+    apt-get update && \
+    DEBIAN_FRONTEND="noninteractive" apt-get install \
+        python${PYTHON_VERSION} \
+        python${PYTHON_VERSION}-distutils \
+        python3-pip -y && \
     python${PYTHON_VERSION} -m pip install pip -U && \
     ln -s $(which python${PYTHON_VERSION}) /usr/local/bin/python && \
     ln -s $(which python${PYTHON_VERSION}) /usr/local/bin/python3 && \

--- a/ppa.dockerfile
+++ b/ppa.dockerfile
@@ -10,14 +10,13 @@ FROM ubuntu:18.04
 ARG PYTHON_VERSION=3.7
 RUN true && \
     apt-get update && \
-    apt-get install software-properties-common -y && \
+    apt-get install software-properties-common curl -y && \
     add-apt-repository ppa:deadsnakes/ppa -y && \
     apt-get update && \
-    DEBIAN_FRONTEND="noninteractive" apt-get install \
+    DEBIAN_FRONTEND="noninteractive" apt-get install -y \
         python${PYTHON_VERSION} \
-        python${PYTHON_VERSION}-distutils \
-        python3-pip -y && \
-    pip3 install pip -U && \
+        python${PYTHON_VERSION}-distutils && \
+    curl -sS https://bootstrap.pypa.io/get-pip.py | python${PYTHON_VERSION} && \
     ln -s $(which python${PYTHON_VERSION}) /usr/local/bin/python && \
     ln -s $(which python${PYTHON_VERSION}) /usr/local/bin/python3 && \
     true

--- a/ppa.dockerfile
+++ b/ppa.dockerfile
@@ -17,7 +17,7 @@ RUN true && \
         python${PYTHON_VERSION} \
         python${PYTHON_VERSION}-distutils \
         python3-pip -y && \
-    python${PYTHON_VERSION} -m pip install pip -U && \
+    pip3 install pip -U && \
     ln -s $(which python${PYTHON_VERSION}) /usr/local/bin/python && \
     ln -s $(which python${PYTHON_VERSION}) /usr/local/bin/python3 && \
     true

--- a/ppa.dockerfile
+++ b/ppa.dockerfile
@@ -1,0 +1,20 @@
+################################################################################
+# This dockerfile builds a base image that can be used to validate the library
+# against ubuntu PPA python builds
+#
+# Reference: https://github.com/IBM/import-tracker/issues/40
+################################################################################
+
+FROM ubuntu:18.04
+
+ARG PYTHON_VERSION=3.7
+RUN true && \
+    apt update && \
+    apt install software-properties-common -y && \
+    add-apt-repository ppa:deadsnakes/ppa -y && \
+    apt update && \
+    apt install python${PYTHON_VERSION} python3-pip -y && \
+    python${PYTHON_VERSION} -m pip install pip -U && \
+    ln -s $(which python${PYTHON_VERSION}) /usr/local/bin/python && \
+    ln -s $(which python${PYTHON_VERSION}) /usr/local/bin/python3 && \
+    true

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,7 +4,7 @@ alchemy-logging>=1.0.3
 PyYaml>=6.0
 # Testing
 pytest>=6.2.5
-pytest-asyncio>=0.17.0
+pytest-asyncio>=0.16.0
 pytest-cov>=3.0.0
 pytest-xdist>=2.5.0
 # This is only used to validate the funky google namespace corner case

--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# If disabled, do nothing (for docker build)
+if [ "${RUN_FMT:-"true"}" != "true" ]
+then
+  echo "fmt disabled"
+  exit
+fi
+
 pre-commit run --all-files
 RETURN_CODE=$?
 
@@ -10,14 +17,14 @@ function echoWarning() {
 }
 
 if [ "$RETURN_CODE" -ne 0 ]; then
-    if [ "${CI}" != "true" ]; then
-      echoWarning "☝️ This appears to have failed, but actually your files have been formatted."
-      echoWarning "Make a new commit with these changes before making a pull request."
-    else
-      echoWarning "This test failed because your code isn't formatted correctly."
-      echoWarning 'Locally, run `make run fmt`, it will appear to fail, but change files.'
-      echoWarning "Add the changed files to your commit and this stage will pass."
-    fi
+  if [ "${CI}" != "true" ]; then
+    echoWarning "☝️ This appears to have failed, but actually your files have been formatted."
+    echoWarning "Make a new commit with these changes before making a pull request."
+  else
+    echoWarning "This test failed because your code isn't formatted correctly."
+    echoWarning 'Locally, run `make run fmt`, it will appear to fail, but change files.'
+    echoWarning "Add the changed files to your commit and this stage will pass."
+  fi
 
-    exit $RETURN_CODE
+  exit $RETURN_CODE
 fi


### PR DESCRIPTION
## Description

This PR addresses #40 by providing more robust heuristics for discovering the standard location of built-in libraries that are implemented as shared libraries.

## Changes

* Add more robust heuristics for discovery `_std_dylib_dir`
* Add a base `ppa.dockerfile` that builds base images using PPA python (where the issue was observed)
* Extend the testing grid to include tests of all versions of python on PPA
* [UNRELATED BUG!] Actually build the unit test jobs against the target python versions!
    * While adding the PPA tests, I realized that the PYTHON_VERSION was never passed as a `--build-arg` to the unit test builds. Fortunately, it was being done correctly for `release`