### PR TITLE
🐛 Direct deps in parse requirements 48

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -8,3 +8,4 @@ import_heading_firstparty=First Party
 import_heading_localfolder=Local
 known_firstparty=alog
 known_localfolder=import_tracker,test,sample_lib,bad_deps,conditional_deps
+skip=test/sample_libs/direct_dep_ambiguous/__init__.py

--- a/import_tracker/__main__.py
+++ b/import_tracker/__main__.py
@@ -503,14 +503,20 @@ def detect_transitive(
         )
         log.debug3("Direct modules for [%s]: %s", module_name, direct_mods)
 
-        # For each dependency, check whether it's in the direct list
+        # If it's just a set of strings, make it a dict
         if isinstance(dependencies, set):
             dependencies = {name: {} for name in dependencies}
+
+        # For each dependency, check whether it's in the direct list
         for dep_name, dep_info in dependencies.items():
+            # If the dep_info is a list, it's a stack trace
+            if isinstance(dep_info, list):
+                dep_info = {"stack": dep_info}
+
             dep_info["type"] = (
                 TYPE_DIRECT if dep_name in direct_mods else TYPE_TRANSITIVE
             )
-        updated_mapping[module_name] = dependencies
+            updated_mapping.setdefault(module_name, {})[dep_name] = dep_info
 
     return updated_mapping
 

--- a/import_tracker/__main__.py
+++ b/import_tracker/__main__.py
@@ -518,6 +518,9 @@ def detect_transitive(
             )
             updated_mapping.setdefault(module_name, {})[dep_name] = dep_info
 
+        # Make sure it's present, even with an empty list
+        updated_mapping.setdefault(module_name, {})
+
     return updated_mapping
 
 

--- a/test/sample_libs/direct_dep_ambiguous/__init__.py
+++ b/test/sample_libs/direct_dep_ambiguous/__init__.py
@@ -1,7 +1,13 @@
-# Import alog here so that is a direct dependency of the top-level
-# First Party
-import alog
+"""
+This sample lib is carefully crafted such that the order of the imports makes
+the allocation of alog ambiguous. As such, we very intentionally have alog after
+the local imports and need to ignore this file in isort.
+"""
 
 # Local
 # Import the two submodules
 from . import bar, foo
+
+# Import alog here so that is a direct dependency of the top-level
+# First Party
+import alog

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -266,7 +266,7 @@ def test_import_stack_tracking(capsys):
     }
 
 
-def test_detect_transitive(capsys):
+def test_detect_transitive_no_stack_traces(capsys):
     """Test that --detect_transitive works as expected"""
     with cli_args(
         "--name",
@@ -295,11 +295,7 @@ def test_detect_transitive(capsys):
                 "type": constants.TYPE_DIRECT,
             },
         },
-        "direct_dep_ambiguous.bar": {
-            "alog": {
-                "type": constants.TYPE_TRANSITIVE,
-            }
-        },
+        "direct_dep_ambiguous.bar": {},
     }
 
 
@@ -329,10 +325,15 @@ def test_detect_transitive_with_stack_traces(capsys):
             "alog": {
                 "stack": [
                     {
-                        "filename": f"{test_lib_dir}/__init__.py",
-                        "lineno": 3,
+                        "filename": f"{test_lib_dir}/foo.py",
+                        "lineno": 6,
                         "code_context": ["import alog"],
-                    }
+                    },
+                    {
+                        "filename": f"{test_lib_dir}/__init__.py",
+                        "lineno": 9,
+                        "code_context": ["from . import bar, foo"],
+                    },
                 ],
                 "type": "direct",
             },
@@ -345,16 +346,30 @@ def test_detect_transitive_with_stack_traces(capsys):
                     },
                     {
                         "filename": f"{test_lib_dir}/__init__.py",
-                        "lineno": 7,
+                        "lineno": 9,
                         "code_context": ["from . import bar, foo"],
                     },
                 ],
                 "type": "transitive",
             },
         },
-        "direct_dep_ambiguous.bar": {"alog": {"stack": [], "type": "transitive"}},
+        "direct_dep_ambiguous.bar": {},
         "direct_dep_ambiguous.foo": {
-            "alog": {"stack": [], "type": "direct"},
+            "alog": {
+                "stack": [
+                    {
+                        "filename": f"{test_lib_dir}/foo.py",
+                        "lineno": 6,
+                        "code_context": ["import alog"],
+                    },
+                    {
+                        "filename": f"{test_lib_dir}/__init__.py",
+                        "lineno": 9,
+                        "code_context": ["from . import bar, foo"],
+                    },
+                ],
+                "type": "direct",
+            },
             "yaml": {
                 "stack": [
                     {
@@ -364,7 +379,7 @@ def test_detect_transitive_with_stack_traces(capsys):
                     },
                     {
                         "filename": f"{test_lib_dir}/__init__.py",
-                        "lineno": 7,
+                        "lineno": 9,
                         "code_context": ["from . import bar, foo"],
                     },
                 ],

--- a/test/test_setup_tools.py
+++ b/test/test_setup_tools.py
@@ -161,3 +161,19 @@ def test_single_extras_module():
         "all": sorted(["alchemy-logging", "PyYaml"]),
         "single_extra.extra": ["PyYaml"],
     }
+
+
+def test_parent_direct_deps():
+    """Make sure that direct dependencies of parent modules are correctly
+    attributed when holding children as extras that also require the same deps
+    """
+    requirements, extras_require = parse_requirements(
+        ["alchemy-logging", "PyYaml"],
+        "direct_dep_ambiguous",
+        ["direct_dep_ambiguous.foo"],
+    )
+    assert requirements == ["alchemy-logging"]
+    assert extras_require == {
+        "all": sorted(["PyYaml", "alchemy-logging"]),
+        "direct_dep_ambiguous.foo": ["PyYaml"],
+    }


### PR DESCRIPTION
## Description

Closes #48 

This PR uses the new `--detect_transitive` argument to differentiate between `direct` and `transitive` dependencies of modules within the target library that are not part of the extras and ensure that all `direct` dependencies of non-extras are held in the common `requirements`.