### PR TITLE
🐛 Lazy module trigger bug

### DIFF
--- a/test/sample_libs/lazy_module/__init__.py
+++ b/test/sample_libs/lazy_module/__init__.py
@@ -1,0 +1,2 @@
+# Local
+from . import mod

--- a/test/sample_libs/lazy_module/lazy_deps.py
+++ b/test/sample_libs/lazy_module/lazy_deps.py
@@ -1,0 +1,4 @@
+# Local
+from import_tracker import LazyModule
+
+alog = LazyModule("alog")

--- a/test/sample_libs/lazy_module/mod.py
+++ b/test/sample_libs/lazy_module/mod.py
@@ -1,0 +1,4 @@
+# Local
+from .lazy_deps import alog
+
+log = alog.use_channel("foobar")

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -387,3 +387,20 @@ def test_detect_transitive_with_stack_traces(capsys):
             },
         },
     }
+
+
+def test_lazy_module_trigger(capsys):
+    """Make sure that a sub-module which holds LazyModule attrs does not
+    incorrectly trigger their imports when run through import_tracker.
+    """
+    with cli_args("--name", "lazy_module", "--recursive"):
+        main()
+    captured = capsys.readouterr()
+    assert captured.out
+    parsed_out = json.loads(captured.out)
+
+    assert parsed_out == {
+        "lazy_module": ["alog"],
+        "lazy_module.lazy_deps": [],
+        "lazy_module.mod": ["alog"],
+    }


### PR DESCRIPTION
## Description

Closes #50 

This PR fixes the accidental `getattr` call that was causing `LazyModule`s held as attributes of other modules to be imported when run through the `import_tracker` main entrypoint.