### PR TITLE
:bug: Fix nested lazy import and sys meta path modification issue

### DIFF
--- a/import_tracker/lazy_import_errors.py
+++ b/import_tracker/lazy_import_errors.py
@@ -114,17 +114,17 @@ class _LazyImportErrorCtx(AbstractContextManager):
         the constructor.
         """
         self.finder = None
-        if sys.meta_path and not any(getattr(finder, "owner_content", None) is self for finder in sys.meta_path):
+        if sys.meta_path and not any(
+            getattr(finder, "owner_content", None) is self for finder in sys.meta_path
+        ):
             self.finder = _LazyErrorMetaFinder(make_error_message, self)
             sys.meta_path.append(self.finder)
-
 
     @staticmethod
     def __enter__():
         """Nothing to do in __enter__ since it's done in __init__"""
         pass
 
-    # @classmethod
     def __exit__(self, *_, **__):
         """On exit, ensure there are no lazy meta finders left"""
         if self.finder in sys.meta_path:
@@ -449,7 +449,11 @@ class _LazyErrorMetaFinder(importlib.abc.MetaPathFinder):
     potentially raise an ImportError when the module is used
     """
 
-    def __init__(self, make_error_message: Optional[Callable[[str], str]], owner_context: _LazyImportErrorCtx):
+    def __init__(
+        self,
+        make_error_message: Optional[Callable[[str], str]],
+        owner_context: _LazyImportErrorCtx,
+    ):
         self._make_error_message = make_error_message
         self.owner_context = owner_context
 

--- a/import_tracker/lazy_import_errors.py
+++ b/import_tracker/lazy_import_errors.py
@@ -113,19 +113,25 @@ class _LazyImportErrorCtx(AbstractContextManager):
         acts as the context manager, so the __enter__ implementation lives in
         the constructor.
         """
-        if sys.meta_path and not isinstance(sys.meta_path[-1], _LazyErrorMetaFinder):
-            sys.meta_path.append(_LazyErrorMetaFinder(make_error_message))
+        self.finder = None
+        if sys.meta_path and not any(getattr(finder, "owner_content", None) is self for finder in sys.meta_path):
+            self.finder = _LazyErrorMetaFinder(make_error_message, self)
+            sys.meta_path.append(self.finder)
+
 
     @staticmethod
     def __enter__():
         """Nothing to do in __enter__ since it's done in __init__"""
         pass
 
-    @classmethod
-    def __exit__(cls, *_, **__):
+    # @classmethod
+    def __exit__(self, *_, **__):
         """On exit, ensure there are no lazy meta finders left"""
-        while sys.meta_path and isinstance(sys.meta_path[-1], _LazyErrorMetaFinder):
-            sys.meta_path.pop()
+        if self.finder in sys.meta_path:
+            sys.meta_path.remove(self.finder)
+        # while sys.meta_path and isinstance(sys.meta_path[-1], _LazyErrorMetaFinder):
+
+        #     sys.meta_path.pop()
 
 
 class _LazyErrorAttr(type):
@@ -443,8 +449,10 @@ class _LazyErrorMetaFinder(importlib.abc.MetaPathFinder):
     potentially raise an ImportError when the module is used
     """
 
-    def __init__(self, make_error_message: Optional[Callable[[str], str]]):
+    def __init__(self, make_error_message: Optional[Callable[[str], str]], owner_context: _LazyImportErrorCtx):
         self._make_error_message = make_error_message
+        self.owner_context = owner_context
+
         self.calling_pkg = None
         self.this_module = sys.modules[__name__].__package__.split(".")[0]
         for pkgname in self._get_non_import_modules():

--- a/import_tracker/lazy_import_errors.py
+++ b/import_tracker/lazy_import_errors.py
@@ -129,9 +129,6 @@ class _LazyImportErrorCtx(AbstractContextManager):
         """On exit, ensure there are no lazy meta finders left"""
         if self.finder in sys.meta_path:
             sys.meta_path.remove(self.finder)
-        # while sys.meta_path and isinstance(sys.meta_path[-1], _LazyErrorMetaFinder):
-
-        #     sys.meta_path.pop()
 
 
 class _LazyErrorAttr(type):

--- a/test/test_lazy_import_errors.py
+++ b/test/test_lazy_import_errors.py
@@ -9,6 +9,7 @@ import shlex
 import subprocess
 import sys
 import tempfile
+from types import ModuleType
 
 # Third Party
 import pytest
@@ -376,3 +377,30 @@ def test_frame_generator_stop():
     correctly if iterated to the end
     """
     list(_LazyErrorMetaFinder._FrameGenerator())
+
+def test_lazy_import_error_nested():
+    """Make sure the each lazy import errors only pops itself off of sys.metapath"""
+    with import_tracker.lazy_import_errors():
+        with import_tracker.lazy_import_errors():
+            pass
+        # Third Party
+        import foobar
+
+
+def test_lazy_import_error_modified_meta_path():
+    """Make sure lazy import error works if sys.meta_path gets modified
+    in between
+    """
+
+    class MockModule:
+        def find_spec(self, *args, **kwargs):
+            pass
+
+    sys.meta_path.append(MockModule)
+    with import_tracker.lazy_import_errors():
+        with import_tracker.lazy_import_errors():
+            pass
+        # Third Party
+        import foobar
+
+    sys.meta_path.remove(MockModule)

--- a/test/test_lazy_import_errors.py
+++ b/test/test_lazy_import_errors.py
@@ -3,13 +3,13 @@ Tests for the lazy_import_errors functionality
 """
 
 # Standard
+from types import ModuleType
 import os
 import pickle
 import shlex
 import subprocess
 import sys
 import tempfile
-from types import ModuleType
 
 # Third Party
 import pytest
@@ -377,6 +377,7 @@ def test_frame_generator_stop():
     correctly if iterated to the end
     """
     list(_LazyErrorMetaFinder._FrameGenerator())
+
 
 def test_lazy_import_error_nested():
     """Make sure the each lazy import errors only pops itself off of sys.metapath"""


### PR DESCRIPTION
### Changes
- Fix case when `sys.meta_path` is modified (appended) by some other library. This issue was noticed when `sys.meta_path` was getting modified by `setuptools.command.build_py`. 
- Fix case when a library implementing lazy import errors (by using import-tracker) was getting used by another library implementing lazy import errors (nested lazy import error case)