### PR TITLE
:bug: Fix inheritance case for lazy imports

### DIFF
--- a/import_tracker/lazy_import_errors.py
+++ b/import_tracker/lazy_import_errors.py
@@ -152,8 +152,9 @@ class _LazyErrorAttr(type):
     ):
         # When this is used as a base class, we need to pass __classcell__
         # through to type.__new__ to avoid a runtime warning.
+
         new_namespace = {}
-        if isinstance(namespace, dict):
+        if isinstance(namespace, dict) and "__classcell__" in namespace:
             new_namespace["__classcell__"] = namespace.get("__classcell__")
         return super().__new__(
             cls, f"_LazyErrorAttr[{missing_module_name}]", (), new_namespace

--- a/test/test_lazy_import_errors.py
+++ b/test/test_lazy_import_errors.py
@@ -405,3 +405,20 @@ def test_lazy_import_error_modified_meta_path():
         import foobar
 
     sys.meta_path.remove(MockModule)
+
+
+def test_lazy_import_error_subclass():
+    """Make sure lazy import error works if a class from another module
+    is used as base class for a module where both of them are in
+    lazy imports and parent uses an optional dependency
+    """
+
+    with import_tracker.lazy_import_errors():
+        # Third Party
+        from foo.bar import Foo
+
+        class Baz(Foo):
+            pass
+
+        class Bar(Baz):
+            pass


### PR DESCRIPTION
### Changes
- Fix case where a class that uses a module from an optional dependency is used as base class for another module, where both classes are in lazy import error
- This fixes following error:
```
    return super().__new__(
TypeError: __classcell__ must be a nonlocal cell, not <class 'NoneType'>
```

### Scenario

- `module_1.py`
```python
from sklearn import LinearSVM

class NewSVM(LinearSVM):
    pass
```
- `module_2.py`
```python
from .module_2 import NewSVM

class Foo(NewSVM):
    pass
```

- where these are included in `lazy_import_errors` because sklearn is an optional dependency
