### PR TITLE
Add fix for typing

### DIFF
--- a/import_tracker/lazy_import_errors.py
+++ b/import_tracker/lazy_import_errors.py
@@ -241,9 +241,10 @@ class _LazyErrorAttr(type):
     def __delitem__(self, *_, **__):
         self._raise()
 
-    def __eq__(self, *_, **__):
+    def __eq__(self, other, *_, **__):
         if not _is_import_time():
             self._raise()
+        return id(self) == id(other)
 
     def __float__(self, *_, **__):
         self._raise()

--- a/import_tracker/lazy_import_errors.py
+++ b/import_tracker/lazy_import_errors.py
@@ -7,7 +7,6 @@ used.
 # Standard
 from contextlib import AbstractContextManager
 from functools import partial
-from random import randint
 from types import ModuleType
 from typing import Callable, Optional, Set
 import importlib.abc
@@ -91,7 +90,6 @@ def _make_extras_import_error(
 
     # Look through frames in the stack to see if there's an extras module
     extras_module = None
-
     for frame in inspect.stack():
         frame_module = frame.frame.f_globals["__name__"]
         if frame_module in extras_modules:
@@ -259,7 +257,7 @@ class _LazyErrorAttr(type):
     def __get__(self, *_, **__):
         self._raise()
 
-    def __getitem__(self, *args, **kwargs):
+    def __getitem__(self, *_, **__):
         self._raise()
 
     def __gt__(self, *_, **__):
@@ -268,7 +266,7 @@ class _LazyErrorAttr(type):
     def __hash__(self, *_, **__):
         if not _is_import_time():
             self._raise()
-        return randint(0, 100000000)
+        return id(self)
 
     def __iadd__(self, *_, **__):
         self._raise()

--- a/import_tracker/lazy_import_errors.py
+++ b/import_tracker/lazy_import_errors.py
@@ -7,6 +7,7 @@ used.
 # Standard
 from contextlib import AbstractContextManager
 from functools import partial
+from random import randint
 from types import ModuleType
 from typing import Callable, Optional, Set
 import importlib.abc
@@ -88,6 +89,7 @@ def _make_extras_import_error(
     # Get the set of extras modules from the library
     extras_modules = get_extras_modules()
 
+
     # Look through frames in the stack to see if there's an extras module
     extras_module = None
 
@@ -153,7 +155,6 @@ class _LazyErrorAttr(type):
     ):
         # When this is used as a base class, we need to pass __classcell__
         # through to type.__new__ to avoid a runtime warning.
-
         new_namespace = {}
         if isinstance(namespace, dict) and "__classcell__" in namespace:
             new_namespace["__classcell__"] = namespace.get("__classcell__")
@@ -244,7 +245,8 @@ class _LazyErrorAttr(type):
         self._raise()
 
     def __eq__(self, *_, **__):
-        self._raise()
+        if not _is_import_time():
+            self._raise()
 
     def __float__(self, *_, **__):
         self._raise()
@@ -258,14 +260,16 @@ class _LazyErrorAttr(type):
     def __get__(self, *_, **__):
         self._raise()
 
-    def __getitem__(self, *_, **__):
+    def __getitem__(self, *args, **kwargs):
         self._raise()
 
     def __gt__(self, *_, **__):
         self._raise()
 
     def __hash__(self, *_, **__):
-        self._raise()
+        if not _is_import_time():
+            self._raise()
+        return randint(0, 100000000)
 
     def __iadd__(self, *_, **__):
         self._raise()

--- a/import_tracker/lazy_import_errors.py
+++ b/import_tracker/lazy_import_errors.py
@@ -89,7 +89,6 @@ def _make_extras_import_error(
     # Get the set of extras modules from the library
     extras_modules = get_extras_modules()
 
-
     # Look through frames in the stack to see if there's an extras module
     extras_module = None
 

--- a/test/sample_libs/type_check_deps/type_check_dict.py
+++ b/test/sample_libs/type_check_deps/type_check_dict.py
@@ -1,0 +1,9 @@
+import import_tracker
+from typing import Dict
+
+with import_tracker.lazy_import_errors():
+    # Third Party
+    from foo.bar import Bar
+
+    def dummy_type_func(var) -> Dict[str, Bar]:
+        pass

--- a/test/sample_libs/type_check_deps/type_check_dict.py
+++ b/test/sample_libs/type_check_deps/type_check_dict.py
@@ -1,5 +1,8 @@
-import import_tracker
+# Standard
 from typing import Dict
+
+# Local
+import import_tracker
 
 with import_tracker.lazy_import_errors():
     # Third Party

--- a/test/sample_libs/type_check_deps/type_check_union.py
+++ b/test/sample_libs/type_check_deps/type_check_union.py
@@ -1,5 +1,8 @@
-import import_tracker
+# Standard
 from typing import Union
+
+# Local
+import import_tracker
 
 with import_tracker.lazy_import_errors():
     # Third Party

--- a/test/sample_libs/type_check_deps/type_check_union.py
+++ b/test/sample_libs/type_check_deps/type_check_union.py
@@ -1,0 +1,9 @@
+import import_tracker
+from typing import Union
+
+with import_tracker.lazy_import_errors():
+    # Third Party
+    from foo import Bar
+
+    def dummy_type_func(var) -> Union[str, Bar]:
+        pass

--- a/test/test_lazy_import_errors.py
+++ b/test/test_lazy_import_errors.py
@@ -434,16 +434,20 @@ def test_lazy_import_error_import_time_dep():
     # Third Party
     from decorator_deps import opt_decorator
 
+
 def test_lazy_import_error_type_dict():
     """Test lazy import error for the case where the call to optional
     dependency happens because of type check for Dict
     """
 
+    # Third Party
     from type_check_deps import type_check_dict
+
 
 def test_lazy_import_error_type_union():
     """Test lazy import error for the case where the call to optional
     dependency happens because of type check for Union
     """
 
+    # Third Party
     from type_check_deps import type_check_union

--- a/test/test_lazy_import_errors.py
+++ b/test/test_lazy_import_errors.py
@@ -433,3 +433,17 @@ def test_lazy_import_error_import_time_dep():
     # calls out to a optional dependency via decorator (hence import time)
     # Third Party
     from decorator_deps import opt_decorator
+
+def test_lazy_import_error_type_dict():
+    """Test lazy import error for the case where the call to optional
+    dependency happens because of type check for Dict
+    """
+
+    from type_check_deps import type_check_dict
+
+def test_lazy_import_error_type_union():
+    """Test lazy import error for the case where the call to optional
+    dependency happens because of type check for Union
+    """
+
+    from type_check_deps import type_check_union


### PR DESCRIPTION
### Changes
- Fixes the issues where an optional dependency class is used for type checking along with other types using a combining type, like Dict or Union.

based on #64 

### Scenarios
1. `Dict[foo, str]`
2. `Union[foo, str]`

Typing is another one of the operations that happens at the import time. 

In both above scenarios, a hashing is performed under the hood in python that tries to make a unique combination of the presented types. Since we are replacing it with lazy module, without this fix, we are raising error for `__hash__` function, and thus the typing at import time, throws error.


