### PR TITLE
:zap: Remove inspect.stack() for performance

### DIFF
--- a/test/test_lazy_import_errors.py
+++ b/test/test_lazy_import_errors.py
@@ -15,7 +15,7 @@ import tempfile
 import pytest
 
 # Local
-from import_tracker.lazy_import_errors import _LazyErrorMetaFinder
+from import_tracker.lazy_import_errors import _FastFrameGenerator, _LazyErrorMetaFinder
 import import_tracker
 
 
@@ -376,7 +376,7 @@ def test_frame_generator_stop():
     """For completeness, we need to ensure that the FrameGenerator will stop
     correctly if iterated to the end
     """
-    list(_LazyErrorMetaFinder._FrameGenerator())
+    list(_FastFrameGenerator())
 
 
 def test_lazy_import_error_nested():


### PR DESCRIPTION
Not gonna lie I don't fully understand what's going on inside of `inspect.stack()` to make it so much slower than iterating through `sys._getframe()` but here we are.

This takes a partial import of a library that makes heavy use of `abc.ABC` from 650s back down to 4s.