### PR TITLE
FixIsortVersionDeps: Use isort 5.11.5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
           - id: black
             exclude: imports
     - repo: https://github.com/PyCQA/isort
-      rev: 5.6.3
+      rev: 5.11.5
       hooks:
           - id: isort
             exclude: imports


### PR DESCRIPTION
This fixes the incompatibility issue with poetry core that showed up in CI. In isort 5.12.0, support for python 3.7 was dropped, so we need to stay below that. This release was a hotfix patch to support <3.8

https://stackoverflow.com/a/75295105
https://github.com/PyCQA/isort/releases/tag/5.11.5