### PR TITLE
Finish new version support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,3 +41,21 @@ jobs:
                   PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
                   PYTHON_VERSION: "3.10"
               run: REF="${{ github.ref }}" ./scripts/release.sh
+    build-311:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - name: Run release
+              env:
+                  PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+                  PYTHON_VERSION: "3.11"
+              run: REF="${{ github.ref }}" ./scripts/release.sh
+    build-312:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - name: Run release
+              env:
+                  PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+                  PYTHON_VERSION: "3.12"
+              run: REF="${{ github.ref }}" ./scripts/release.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ FROM test as release
 ARG PYPI_TOKEN
 ARG RELEASE_VERSION
 ARG RELEASE_DRY_RUN
-RUN ./scripts/publish.sh
+RUN ./scripts/publish.sh && touch /released.txt
 
 ## Release Test ################################################################
 #
@@ -53,6 +53,9 @@ RUN ./scripts/publish.sh
 FROM base as release_test
 ARG RELEASE_VERSION
 ARG RELEASE_DRY_RUN
+# Force a dependency on the release phase so that buildkit doesn't run these in
+# parallel
+COPY --from=release /released.txt /released.txt
 COPY ./test /src/test
 COPY ./scripts/run_tests.sh /src/scripts/run_tests.sh
 COPY ./scripts/install_release.sh /src/scripts/install_release.sh

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -6,11 +6,6 @@ cd $(dirname ${BASH_SOURCE[0]})/..
 # Get the tag for this release
 tag=$(echo $REF | cut -d'/' -f3-)
 
-# We explicitly don't want to run with buildkit so that the docker builds happen
-# in a linear fashion since our `release_test` stages intentionally don't
-# inherit from the stages where the publication happens.
-export DOCKER_BUILDKIT=0
-
 # Build the docker phase that will release and then test it
 docker build . \
     --target=release_test \

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,8 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
     keywords=["import", "importlib", "dependencies"],
     packages=["import_tracker"],


### PR DESCRIPTION
This PR fixes some issues in the `3.2.0` release that failed to build the wheels for `3.11`/`3.12`